### PR TITLE
Don't save an empty string as the nil value of enums

### DIFF
--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -32,6 +32,10 @@ module RailsAdmin
           register_instance_option :multiple? do
             properties && [:serialized].include?(properties.type)
           end
+          
+          def parse_input(params)
+            params[name] = params[name].presence
+          end
         end
       end
     end


### PR DESCRIPTION
When configuring a field as an enum, rails_admin automatically adds a nil option. However, when parsing the input, it's picked up as an empty string.

See: https://github.com/sferik/rails_admin/commit/ac0344fc7f52bb3fc55b57dd9d0ec8937e7b7143

By mapping the empty value to nil, we ensure compatibility with the new [ActiveRecord::Enum](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html) and [mongoid-enum](https://github.com/thetron/mongoid-enum), which make special allowances in their validations for nil values, but not empty strings.

One last thing we could add is to allow an empty string, if it's one of the values specified in the `enum`. But I'm not really familiar with the scopes involved, so I won't add that.